### PR TITLE
add get-codeartifact-token action

### DIFF
--- a/.github/actions/get-codeartifact-token/action.yaml
+++ b/.github/actions/get-codeartifact-token/action.yaml
@@ -1,0 +1,55 @@
+name: Get CodeArtifact Token
+description: Get a CodeArtifact Token to login into CodeArtifact repositories
+inputs:
+  domain:
+    description: CodeArtifact Domain of your repositories
+    required: true
+    type: string
+  domain-owner:
+    description: CodeArtifact Domain Owner (AWS Account ID)
+    required: true
+    type: string
+  token-duration:
+    description: CodeArtifact Token duration (in seconds)
+    required: false
+    default: 3600
+    type: number
+  aws-access-key-id:
+    description: AWS ACCESS KEY ID
+    required: true
+    type: string
+  aws-secret-access-key:
+    description: AWS SECRET ACCESS KEY
+    required: true
+    type: string
+  aws-region:
+    description: AWS Region
+    default: us-west-2
+    required: false
+    type: string
+outputs:
+  token:
+    description: Code Artifact Token
+    value: ${{ steps.token.outputs.value }}
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+    - name: Get Token
+      id: token
+      shell: bash
+      run: |
+        TOKEN=$(
+          aws codeartifact get-authorization-token \
+            --domain ${{ inputs.domain }} \
+            --domain-owner ${{ inputs.domain-owner }} \
+            --region ${{ inputs.aws-region }} \
+            --query authorizationToken \
+            --duration-seconds ${{ inputs.token-duration }} \
+            --output text)
+        echo "value=${TOKEN}" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
 ```
 
-### Actions
+### Actions
 
 - `build-and-push-to-ecr`:
 ```yaml
@@ -57,3 +57,39 @@ jobs:
     docker-image: myregistry/myimage:tag
     container-name: my_container
 ```
+
+- `get-codeartifact-token`:
+```yaml
+- uses: actions/checkout@v3
+- name: Get CodeArtifact Token
+  id: token
+  uses: AuDigent/gha-workflows/.github/actions/get-codeartifact-token@0.4.0
+  with:
+    domain: my-domain
+    domain-owner: 1111111   # Your AWS Account ID
+    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+- uses: actions/setup-python@v4
+  with:
+    python-version: '3.9'
+    cache: 'pipenv'
+- name: install dependencies
+  env:
+    CODEARTIFACT_AUTH_TOKEN: ${{ steps.token.outputs.token }}
+  run: |
+    pip install pipenv
+    pipenv install --dev --ignore-pipfile
+```
+
+Example of pipenv config:
+```
+[[source]]
+name = "aws"
+url = "https://aws:${CODEARTIFACT_AUTH_TOKEN}@xxxxxx.d.codeartifact.us-east-1.amazonaws.com/pypi/xxxxx/simple/"
+verify_ssl = true
+
+[packages]
+your-package = { version = "~=1.0", index = "aws" }
+```
+
+Example of IAM Policies to grant access to the repositories available [here](https://docs.aws.amazon.com/codeartifact/latest/ug/auth-and-access-control-iam-identity-based-access-control.html)


### PR DESCRIPTION
**Changes**:
- add get-codeartifact-token action, which allows to login into codeartifact repositories. (I did not found an official or well maintained action that does the same in github)

**Tests**:
- Tested as a local action in another repo

**Post Merge**:
- Create `0.4.0` tag

