### PR TITLE
Add option to disable docker cache

### DIFF
--- a/.github/actions/build-and-push-to-ecr/action.yml
+++ b/.github/actions/build-and-push-to-ecr/action.yml
@@ -72,5 +72,5 @@ runs:
         push: true
         tags: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repository-name }}:${{ inputs.docker-image-tag }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha
         build-args: ${{ inputs.docker-build-args }}

--- a/.github/actions/build-and-push-to-ecr/action.yml
+++ b/.github/actions/build-and-push-to-ecr/action.yml
@@ -32,6 +32,11 @@ inputs:
     default: "."
     required: false
     type: string
+  docker-no-cache:
+    description: disable docker cache
+    default: false
+    required: false
+    type: bool
   docker-build-args:
     description: "List of arguments used during docker build: ARG=VALUE"
     default: ""
@@ -72,5 +77,6 @@ runs:
         push: true
         tags: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repository-name }}:${{ inputs.docker-image-tag }}
         cache-from: type=gha
-        cache-to: type=gha
+        cache-to: type=gha,mode=max
         build-args: ${{ inputs.docker-build-args }}
+        no-cache: ${{ inputs.docker-no-cache }}


### PR DESCRIPTION
- Github action docker cache currently has some annoying bugs depending of the complexitiy of your image. So, I added an option to disable it.